### PR TITLE
Add in basic displayer functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,8 +74,10 @@ testOptions in (ThisBuild, Test) += Tests.Argument("-oDF")
 // Build-wide dependencies
 resolvers in ThisBuild  ++= Seq(
   "Apache Snapshots" at "http://repository.apache.org/snapshots/",
-  "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+  "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/", 
+  "Jitpack repository" at "https://jitpack.io"
 )
+
 updateOptions in ThisBuild := updateOptions.value.withCachedResolution(true)
 libraryDependencies in ThisBuild ++= Seq(
   Dependencies.scalaTest % "test",

--- a/kernel-api/src/main/scala/org/apache/toree/kernel/api/DisplayMethodsLike.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/kernel/api/DisplayMethodsLike.scala
@@ -43,8 +43,15 @@ trait DisplayMethodsLike {
   def javascript(data: String): Unit = content("application/javascript", data)
 
   /**
+    * Send the full bundle of display options to the client
+    * @param bundle The content to send for display
+    */
+  def fullBundle(bundle: Map[String, String]): Unit
+
+  /**
    * Sends a clear-output message to client
    * @param wait if true, client waits for next display_data to clear
    */
   def clear(wait: Boolean = false): Unit
+
 }

--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -14,11 +14,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License
  */
+
 fork in Test := true
 libraryDependencies ++= Dependencies.sparkAll.value
+
+libraryDependencies += Dependencies.displayers
 
 //
 // TEST DEPENDENCIES
 //
 libraryDependencies += Dependencies.akkaTestkit % "test"
-

--- a/kernel/src/main/scala/org/apache/toree/kernel/api/DisplayMethods.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/api/DisplayMethods.scala
@@ -18,6 +18,7 @@
 package org.apache.toree.kernel.api
 
 import org.apache.toree.kernel.protocol.v5
+import org.apache.toree.kernel.protocol.v5.MIMEType.MIMEType
 import org.apache.toree.kernel.protocol.v5.{KMBuilder, KernelMessage}
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 
@@ -36,6 +37,17 @@ class DisplayMethods(
 
   override def content(mimeType: String, data: String): Unit = {
     val displayData = v5.content.DisplayData("user", Map(mimeType -> data), Map())
+
+    val kernelMessage = kmBuilder
+      .withIds(Seq(v5.content.DisplayData.toTypeString.getBytes))
+      .withHeader(v5.content.DisplayData.toTypeString)
+      .withContentString(displayData).build
+
+    actorLoader.load(v5.SystemActorType.KernelMessageRelay) ! kernelMessage
+  }
+
+  override def fullBundle(bundle: Map[String, String]): Unit = {
+    val displayData = v5.content.DisplayData("user", bundle.asInstanceOf[Map[MIMEType, String]], Map())
 
     val kernelMessage = kmBuilder
       .withIds(Seq(v5.content.DisplayData.toTypeString.getBytes))

--- a/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
@@ -43,6 +43,9 @@ import scala.language.dynamics
 import scala.reflect.runtime.universe._
 import scala.util.{DynamicVariable, Try}
 import org.apache.toree.plugins.SparkReady
+import jupyter.Displayers
+import scala.collection.JavaConverters._
+
 
 /**
  * Represents the main kernel API to be used for interaction.
@@ -152,6 +155,12 @@ class Kernel (
           (false, errMsg)
       }
     }).getOrElse((false, "Error!"))
+  }
+
+  def displayData(replObject: Any): Unit = {
+    val outputMap = Displayers.display(replObject)
+    val scalaMap = outputMap.asScala.toMap
+    display().fullBundle(scalaMap)
   }
 
   /**
@@ -341,6 +350,7 @@ class Kernel (
 
   override def createSparkContext(conf: SparkConf): SparkContext = {
     val sconf = createSparkConf(conf)
+
     val _sparkSession = SparkSession.builder.config(sconf).getOrCreate()
 
     val sparkMaster = sconf.getOption("spark.master").getOrElse("not_set")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,6 +66,9 @@ object Dependencies {
 
   val springCore = "org.springframework" % "spring-core" % "4.1.1.RELEASE"// Apache v2
 
+  val displayers = 	"com.github.jupyter" % "jvm-repr" % "0.1.0"
+
+
   // Projects
 
   val sparkAll = Def.setting{

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -51,7 +51,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
    private[scala] var taskManager: TaskManager = _
 
   /** Since the ScalaInterpreter can be started without a kernel, we need to ensure that we can compile things.
-      Adding in the default classpaths as needed.
+    * Adding in the default classpaths as needed.
     */
   def appendClassPath(settings: Settings): Settings = {
     settings.classpath.value = buildClasspath(_thisClassloader)
@@ -90,6 +90,9 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
      bindSparkSession()
      bindSparkContext()
      defineImplicits()
+
+     //TODO: if, some display flag:
+     defineDisplayers()
 
      this
    }
@@ -131,6 +134,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
    protected def bindKernelVariable(kernel: KernelLike): Unit = {
      logger.warn(s"kernel variable: ${kernel}")
+
 //     InterpreterHelper.kernelLike = kernel
 //     interpret("import org.apache.toree.kernel.interpreter.scala.InterpreterHelper")
 //     interpret("import org.apache.toree.kernel.api.Kernel")
@@ -316,6 +320,45 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
      }
    }
+
+  def defineDisplayers(): Unit = {
+    val code =
+      """
+        |import jupyter.Displayer
+        |import jupyter.Displayers
+        |import scala.collection.JavaConverters._
+        |import org.apache.spark.sql.DataFrame
+        |import play.api.libs.json.{JsObject, Json}
+        |
+        |Displayers.register(classOf[DataFrame],
+        |    new Displayer[DataFrame] {
+        |      override def display(frame: DataFrame): java.util.Map[String, String] = {
+        |				val schema = frame.columns
+        |				val dataJson = frame.select("*").toJSON
+        |        val thHTML = schema.map(col => {"<th>"+col+"</th>"}).foldLeft("")(_+_)
+        |        val trHTML = frame.rdd.map(row => {
+        |            val tr = row.toSeq.map(entry => {
+        |              val entryString = if (entry == null) "" else entry.toString
+        |            "<td>"+entryString+"</td>"}).foldLeft("")(_+_)
+        |            "<tr>"+tr+"</tr>"}).collect().foldLeft("")(_+_)
+        |        val frameHTML = "<table><tr>"+thHTML.toString+"</tr>"+trHTML.toString+"</table>"
+        |        Map(
+        |          "text/plain" -> frame.toString(),
+        |          "text/html" ->  frameHTML,
+        |					"application/vnd.dataresource+json" ->
+        |					 JsObject(Seq(
+        |						"schema" -> JsObject(Seq("fields" -> Json.toJson(schema))),
+        |             "data" -> Json.toJson(dataJson.collect())
+        |					 )).toString()
+        |        ).asJava
+        |      }
+        |    })
+        |
+        |def display(replObject: Any): Unit = { kernel.displayData(replObject) }
+        |
+      """.stripMargin
+    doQuietly(interpret(code))
+  }
 
   def defineImplicits(): Unit = {
     val code =


### PR DESCRIPTION
Add displayer support for jvm objects ([jvm-repr](https://github.com/jupyter/jvm-repr)), to start this just covers DataSet/DataFrames. To make calling this possible, there is now a new 
kernel method "displayData", which gathers the Display.display() bundle 
of an object, and sends it as a display_data message. Support for display_data
messages with a mime bundle (as opposed to just one mime type) has been added as well. 

For now, the DataSet/DataFrame displayer implementation is injected into the interpreter 
on startup. Once libraries begin using this on their own, this will no longer be necessary. Additionally, a custom display method has been injected into the interpreter (much like for other 
interpreter startup code) to allow users in the kernel to call display(obj) and generate the Displayers payload.  
 